### PR TITLE
Handle invalid JSON in WebSocket messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,14 @@ wss.on("connection", (ws) => { // wsServer || wss AND request || connection
 
   ws.on("message", (message) => {
     // connection || wss
-    const result = JSON.parse(message);
+    let result;
+    try {
+      result = JSON.parse(message);
+    } catch (err) {
+      console.error("Error parsing message", err);
+      ws.close();
+      return;
+    }
 
     // a user want to create a new game
     if (result.method === "create") {


### PR DESCRIPTION
## Summary
- add try/catch around JSON.parse in WebSocket message handler
- log parsing errors and close offending connection

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2f51040c83298900f7900f34e8c1