### PR TITLE
Use crypto-based UUIDs and flexible room IDs

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,12 @@ const express = require("express");
 const app = express();
 const server = require("http").createServer(app);
 const PORT = process.env.PORT || 8080;
-const WebSocket = require("ws")
-const WEB_URL = process.env.NODE_ENV === "production" ? `https://${process.env.DOMAIN_NAME}/` : `http://localhost:${PORT}/`;
+const WebSocket = require("ws");
+const crypto = require("crypto");
+const WEB_URL =
+  process.env.NODE_ENV === "production"
+    ? `https://${process.env.DOMAIN_NAME}/`
+    : `http://localhost:${PORT}/`;
 
 const wss = new WebSocket.Server({ server:server })
 
@@ -757,23 +761,11 @@ wss.on("connection", (ws) => { // wsServer || wss AND request || connection
 });
 
 // Generates unique guid (i.e. unique user ID)
-const guid = () => {
-  const s4 = () =>
-    Math.floor((1 + Math.random()) * 0x10000)
-      .toString(16)
-      .substring(1);
-  return `${s4() + s4()}-${s4()}-${s4()}-${s4()}-${s4() + s4() + s4()}`;
-};
+const guid = () => crypto.randomUUID();
 
 // Random Part ID
 function partyId() {
-  var result = "";
-  var characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  var charactersLength = characters.length;
-  for (var i = 0; i < 6; i++) {
-    result += characters.charAt(Math.floor(Math.random() * charactersLength));
-  }
-  return result;
+  return crypto.randomUUID();
 }
 
 app.get("/offline", (req, res) => {

--- a/public/js/client.js
+++ b/public/js/client.js
@@ -412,13 +412,13 @@ function resetGameState() {
 }
 
 window.addEventListener("load", (event) => {
-  if (window.location.href.length - 1 > window.origin.length) {
-    const str2 = window.location.href;
-    getRouteId = str2.substring(str2.length - 6);
-    const payLoadRoute = {
-      method: "getRoute",
-      getRouteId: getRouteId,
-    };
+    if (window.location.href.length - 1 > window.origin.length) {
+      const str2 = window.location.href;
+      getRouteId = str2.split("/").pop();
+      const payLoadRoute = {
+        method: "getRoute",
+        getRouteId: getRouteId,
+      };
     ws.send(JSON.stringify(payLoadRoute));
   }
 });
@@ -528,12 +528,12 @@ ws.onmessage = (message) => {
     player = game.player;
     spectators = game.spectators;
     playerSlotHTML = response.playerSlotHTML;
-    roomId = response.roomId;
+      roomId = response.roomId;
 
-    roomId = gameId.substring(gameId.length - 6);
-    if (offline !== true) {
-      window.history.pushState("game", "Title", "/" + roomId);
-    }
+      roomId = gameId.split("/").pop();
+      if (offline !== true) {
+        window.history.pushState("game", "Title", "/" + roomId);
+      }
   }
 
   // Assigns the "clientId" to "theClient" + some styling
@@ -1428,9 +1428,9 @@ setTimeout(joinByUrl, 200);
 function joinByUrl() {
   // If player has a roomId in his url
   if (window.location.href.length - 1 > window.origin.length) {
-    // Get last 6 values from url
+    // Get roomId from the url path
     const str = window.location.href;
-    roomId = str.substring(str.length - 6);
+    roomId = str.split("/").pop();
     gameId = `${location.origin}/` + roomId;
 
     // To prevent bug at 714


### PR DESCRIPTION
## Summary
- Replace custom guid and partyId helpers with `crypto.randomUUID()`
- Extract room and route IDs from URL paths instead of fixed-length substrings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2f6acd708329a53e4acc5d53a885