### PR TITLE
feat: add game chat broadcast

### DIFF
--- a/index.js
+++ b/index.js
@@ -751,6 +751,22 @@ wss.on("connection", (ws) => { // wsServer || wss AND request || connection
       });
     }
 
+    if (result.method === "chat") {
+      const { gameId, message, nickname } = result;
+      const game = games[gameId];
+      if (!game) return;
+      if (!game.chat) game.chat = [];
+      const entry = { nickname, message, ts: Date.now() };
+      game.chat.push(entry);
+      [...game.players, ...game.spectators].forEach((c) => {
+        if (clients[c.clientId]) {
+          clients[c.clientId].ws.send(
+            JSON.stringify({ method: "chat", entry })
+          );
+        }
+      });
+    }
+
     if (result.method === "syncGame") {
       const gameId = result.gameId;
       let game = games[gameId];


### PR DESCRIPTION
## Summary
- add chat message handling in WebSocket message handler
- broadcast chat to players and spectators in a game

## Testing
- `node --check index.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc33781b908329a5efa3c2c8c6e152